### PR TITLE
Update qtawesome to version 1.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.3" %}
 
 package:
   name: qtawesome
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/q/qtawesome/QtAwesome-{{ version }}.tar.gz
-  sha256: 771dd95ac4f50d647d18b4e892fd310a580b56d258476554c7b3498593dfd887
+  sha256: d37bbeb69ddc591e5ff036b741bda8d1d92133811f1f5a7150021506f70b8e6e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ build:
   skip: true  # [ppc64le or s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-
+  entry_points:
+    - qta-browser=qtawesome.icon_browser:run
 requirements:
   host:
     - python
@@ -21,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   build:
-      - {{ cdt('mesa-libgl') }}  # [linux]
+    - {{ cdt('mesa-libgl') }}  # [linux]
   run:
     - python >=3.6
     - qtpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [ppc64le]
-  skip: true  # [s390x]
+  skip: true  # [ppc64le or s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   build:
       - {{ cdt('mesa-libgl') }}  # [linux]
   run:
@@ -29,6 +31,7 @@ test:
     - pyqt
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - pip
+    - python <3.10
   commands:
     - pip check
   imports:
@@ -38,6 +41,7 @@ about:
   home: https://github.com/spyder-ide/qtawesome
   license: MIT
   license_file: LICENSE.txt
+  license_family: MIT
   summary: Iconic fonts in PyQt and PySide applications
   dev_url: https://github.com/spyder-ide/qtawesome
   doc_url: https://qtawesome.readthedocs.io/en/latest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [ppc64le]
-  skip: true  # [linux-s390x]
+  skip: true  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [ppc64le]
+  skip: true  # [linux-s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -28,6 +29,9 @@ test:
   requires:
     - pyqt
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - pip
+  commands:
+    - pip check
   imports:
     - qtawesome
 
@@ -36,6 +40,8 @@ about:
   license: MIT
   license_file: LICENSE.txt
   summary: Iconic fonts in PyQt and PySide applications
+  dev_url: https://github.com/spyder-ide/qtawesome
+  doc_url: https://qtawesome.readthedocs.io/en/latest
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
1. check the upstream
https://github.com/spyder-ide/qtawesome/tree/v1.0.3

2. check the pinnings
https://github.com/spyder-ide/qtawesome/blob/v1.0.3/setupbase.py
https://github.com/spyder-ide/qtawesome/blob/v1.0.3/setup.py
https://github.com/spyder-ide/qtawesome/blob/v1.0.3/setup.cfg

3. check changelogs
https://github.com/spyder-ide/qtawesome/blob/v1.0.3/CHANGELOG.md

There are some important changes mentioned in the change log for version 1.0.3
There are some issues that were corrected. 

There is only one potential breaking issue related to a bug fix
Implicit integer conversion is deprecated
https://github.com/spyder-ide/qtawesome/issues/162
This issue has been closed

There rest of the changes are bug fixes 

Cast tileWidth to an integer
https://github.com/spyder-ide/qtawesome/pull/163

Timer should belong to parent widget
https://github.com/spyder-ide/qtawesome/pull/146


4. additional research
https://github.com/conda-forge/qtawesome-feedstock/issues

There are no open issues mentioned in conda-forge

5. added the dev_url
dev_url: https://github.com/spyder-ide/qtawesome

6. added the doc_url
doc_url: https://qtawesome.readthedocs.io/en/latest

7. added pip to the test section
9. verify the test section
10. additional tests

In order to test the `qtawesome` package version `1.0.3` we use the following command:
`conda build qtawesome-feedstock --test`
The test result was the following:
`All tests passed` 

In addition, the following test were made:
The `qtawesome` package version `1.0.3` was tested using the `spyder` package
The pinnings for `qtawesome` were modified to reflect the latest changes
The following command was used for testing:
`conda build spyder-feedstock --test`
The test result was the following 
`All tests passed`

Based on the research and test results we can conclude that it is safe to update `qtawesome` to version `1.0.3`