### PR TITLE
qtawesome 1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.3" %}
+{% set version = "1.1.1" %}
 
 package:
   name: qtawesome
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/q/qtawesome/QtAwesome-{{ version }}.tar.gz
-  sha256: d37bbeb69ddc591e5ff036b741bda8d1d92133811f1f5a7150021506f70b8e6e
+  sha256: ec02e200231fa68a146a93845890aa0432a7edcba14bf811ff6975cf9acdab5d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,22 @@ source:
 build:
   number: 0
   # we did not support earlier versions of qtawesome for ppc64le or s390x
-  skip: true  # [ppc64le or s390x or py<36]
+  skip: true  # [ppc64le or s390x]
+  # the package is only building as noarch for now
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - qta-browser=qtawesome.icon_browser:run
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
     - setuptools
     - wheel
   build:
     - {{ cdt('mesa-libgl') }}  # [linux]
   run:
-    - python
+    - python >=3.6
     - qtpy
 
 test:
@@ -32,7 +34,6 @@ test:
     - pyqt
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - pip
-    - python
   commands:
     - pip check
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [ppc64le or s390x]
-  noarch: python
+  # we did not support earlier versions of qtawesome for ppc64le or s390x
+  skip: true  # [ppc64le or s390x or py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - qta-browser=qtawesome.icon_browser:run
@@ -24,7 +24,7 @@ requirements:
   build:
     - {{ cdt('mesa-libgl') }}  # [linux]
   run:
-    - python >=3.6
+    - python
     - qtpy
 
 test:
@@ -32,7 +32,7 @@ test:
     - pyqt
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - pip
-    - python <3.10
+    - python
   commands:
     - pip check
   imports:


### PR DESCRIPTION
`qtawesome` version `1.1.1`
1. - [x] Check the upstream
     https://github.com/spyder-ide/qtawesome/tree/v1.1.1

2. - [x] Check the pinnings

     minimum required version of `python` is `3.6`:
     https://github.com/spyder-ide/qtawesome/blob/v1.1.1/setup.py#L41

     `python 3.10` is also supported:
     https://github.com/spyder-ide/qtawesome/blob/v1.1.1/setup.py#L53


3. - [x] Check the changelogs

    https://github.com/spyder-ide/qtawesome/blob/v1.1.1/CHANGELOG.md

    `There are some deprecationn warnings for older versions of fontawesome:`

    Issue 178 - Add deprecation warning for Font Awesome 4.x - 4.7 (PR 185 by @dalthviz)

    `There are some changes on how QT methods are used:`
     
     PR 186 - PR: Try calling newer Qt methods first before falling back to deprecated/removed ones, by @kumattau

     PR 183 - PR: Change to "Ctrl+F" because PyQt6 doesn't support Modifier + Key, by @kumattau

    `The rest of the changes were bug fixes or new features`

4. - [x] Additional research
    https://github.com/conda-forge/qtawesome-feedstock/issues

    there were no open issues mentioned in the upstream at the time of the review. 

    It might be interesting to know if we want to support `qtawesome` for `ppc64le` or `s390x`. Historically we did not provide support for qtawesome for `ppc64le` or `s390x`. 

    While we currently are not building noarch packages, it seems that the package can only build as a noarch at the moment. 

5. - [x] Verify the `dev_url`
    https://github.com/spyder-ide/qtawesome


6. - [x] Verify the `doc_url`
    https://qtawesome.readthedocs.io/en/latest


7. - [x] License is `spdx` compliant

    https://spdx.org/licenses/MIT.html

8. - [x] License family is present
9. - [x] Verify that the build number is correct
10. - [x] Verify if the package needs `setuptools`
    
    `setuptools` is required:
    https://github.com/spyder-ide/qtawesome/blob/v1.1.1/setup.py#L6

11. - [x] Verify if the package needs `wheel`
    
    `wheel is used` 
    https://github.com/spyder-ide/qtawesome/blob/v1.1.1/setup.cfg#L1

12. - [x] `pip` in the test section
13. - [x] veriy the test section
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `qtawesome` to version `1.1.1` for most architectures.
